### PR TITLE
Update client quickstarts to reference latest nuget packages

### DIFF
--- a/Microsoft.WindowsAzure.Mobile.Build.msbuild
+++ b/Microsoft.WindowsAzure.Mobile.Build.msbuild
@@ -123,8 +123,8 @@
     <Exec Command='"$(NugetExe)" install Microsoft.Azure.Mobile.Server.Entity -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\backend\dotnet\packages"' LogStandardErrorAsError="true" />
     <Exec Command='"$(NugetExe)" install Microsoft.Azure.Mobile.Server.Tables -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\backend\dotnet\packages"' LogStandardErrorAsError="true" />
     <Exec Command='"$(NugetExe)" install Microsoft.Azure.Mobile.Server.AppService -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\backend\dotnet\packages"' LogStandardErrorAsError="true" />
-    <Exec Command='"$(NugetExe)" install WindowsAzure.MobileServices -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\packages\sdk"' LogStandardErrorAsError="true" />
-    <Exec Command='"$(NugetExe)" install WindowsAzure.MobileServices.SQLiteStore -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\packages\sqllitestore"' LogStandardErrorAsError="true" />
+    <Exec Command='"$(NugetExe)" install WindowsAzure.MobileServices -Prerelease -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\packages\sdk"' LogStandardErrorAsError="true" />
+    <Exec Command='"$(NugetExe)" install WindowsAzure.MobileServices.SQLiteStore -Prerelease -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\packages\sqllitestore"' LogStandardErrorAsError="true" />
     <Exec Command='"$(NugetExe)" install WindowsAzure.MobileServices.WinJS -source $(NugetPackageSource) -o "$(MSBuildProjectDirectory)\packages"' LogStandardErrorAsError="true" />
   </Target>
 

--- a/client/xamarin.android/ZUMOAPPNAME/ZUMOAPPNAME.tt
+++ b/client/xamarin.android/ZUMOAPPNAME/ZUMOAPPNAME.tt
@@ -61,10 +61,10 @@
       <HintPath>..\packages\WindowsAzure.MobileServices.SQLiteStore.<#= StoreSDKVersion #>\lib\portable-win+net45+wp8+wpa81+monotouch+monoandroid\Microsoft.WindowsAzure.Mobile.SQLiteStore.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCL">
-      <HintPath>..\packages\SQLitePCL.3.8.5.1\lib\MonoAndroid\SQLitePCL.dll</HintPath>
+      <HintPath>..\packages\SQLitePCL.3.8.7.2\lib\MonoAndroid\SQLitePCL.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCL.Ext">
-      <HintPath>..\packages\SQLitePCL.3.8.5.1\lib\MonoAndroid\SQLitePCL.Ext.dll</HintPath>
+      <HintPath>..\packages\SQLitePCL.3.8.7.2\lib\MonoAndroid\SQLitePCL.Ext.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/client/xamarin.android/ZUMOAPPNAME/packages.config
+++ b/client/xamarin.android/ZUMOAPPNAME/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="MonoAndroid22" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="MonoAndroid22" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoAndroid22" />
-  <package id="SQLitePCL" version="3.8.5.1" targetFramework="MonoAndroid22" />
-  <package id="WindowsAzure.MobileServices" version="1.3.0" targetFramework="MonoAndroid22" />
-  <package id="WindowsAzure.MobileServices.SQLiteStore" version="1.0.0" targetFramework="MonoAndroid22" />
+  <package id="SQLitePCL" version="3.8.7.2" targetFramework="MonoAndroid22" />
+  <package id="WindowsAzure.MobileServices" version="2.0.0-alpha" targetFramework="MonoAndroid22" />
+  <package id="WindowsAzure.MobileServices.SQLiteStore" version="1.0.2-alpha" targetFramework="MonoAndroid22" />
 </packages>

--- a/client/xamarin.iOS/ZUMOAPPNAME/ZUMOAPPNAME.tt
+++ b/client/xamarin.iOS/ZUMOAPPNAME/ZUMOAPPNAME.tt
@@ -69,10 +69,10 @@
       <HintPath>..\packages\WindowsAzure.MobileServices.SQLiteStore.<#= StoreSDKVersion #>\lib\portable-win+net45+wp8+wpa81+monotouch+monoandroid\Microsoft.WindowsAzure.Mobile.SQLiteStore.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCL">
-      <HintPath>..\packages\SQLitePCL.3.8.5.1\lib\MonoTouch\SQLitePCL.dll</HintPath>
+      <HintPath>..\packages\SQLitePCL.3.8.7.2\lib\MonoTouch\SQLitePCL.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCL.Ext">
-      <HintPath>..\packages\SQLitePCL.3.8.5.1\lib\MonoTouch\SQLitePCL.Ext.dll</HintPath>
+      <HintPath>..\packages\SQLitePCL.3.8.7.2\lib\MonoTouch\SQLitePCL.Ext.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>

--- a/client/xamarin.iOS/ZUMOAPPNAME/packages.config
+++ b/client/xamarin.iOS/ZUMOAPPNAME/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="MonoTouch10" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="MonoTouch10" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="MonoTouch10" />
-  <package id="SQLitePCL" version="3.8.5.1" targetFramework="MonoTouch10" />
-  <package id="WindowsAzure.MobileServices" version="1.3.0" targetFramework="MonoTouch10" />
-  <package id="WindowsAzure.MobileServices.SQLiteStore" version="1.0.0" targetFramework="MonoTouch10" />
+  <package id="SQLitePCL" version="3.8.7.2" targetFramework="MonoTouch10" />
+  <package id="WindowsAzure.MobileServices" version="2.0.0-alpha" targetFramework="MonoTouch10" />
+  <package id="WindowsAzure.MobileServices.SQLiteStore" version="1.0.2-alpha" targetFramework="MonoTouch10" />
 </packages>


### PR DESCRIPTION
- Sqlitestore has a dependency on sqlitepcl 3.8.7.2. Updated versions in packages.configs accordingly.
- Added prerelease argument to 'nuget install' commands wherever necessary. In general it will be a good idea to make it configurable, but for now hardcoding it.
