### PR TITLE
adding cors references back to quickstart

### DIFF
--- a/backend/dotnet/Quickstart/ZUMOAPPNAMEService/ZUMOAPPNAMEService.tt
+++ b/backend/dotnet/Quickstart/ZUMOAPPNAMEService/ZUMOAPPNAMEService.tt
@@ -104,6 +104,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath><#= this.GetHintPath(nugetPackages, "Microsoft.AspNet.WebApi.Core")#>\System.Web.Http.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Cors">
+      <HintPath><#= this.GetHintPath(nugetPackages, "Microsoft.AspNet.Cors")#>\System.Web.Cors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Cors">
+      <HintPath><#= this.GetHintPath(nugetPackages, "Microsoft.AspNet.WebApi.Cors")#>\System.Web.Http.Cors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Http.OData">
       <HintPath><#= this.GetHintPath(nugetPackages, "Microsoft.AspNet.WebApi.OData")#>\System.Web.Http.OData.dll</HintPath>
     </Reference>


### PR DESCRIPTION
These really shouldn't be here but there's a bug in the nuget dependencies (soon to be fixed) that adds Cors when we don't want it. But nuget restore doesn't re-add references so doing anything with Cors currently requires some manual interaction. I'll undo this once the real fix is deployed.
